### PR TITLE
Fixes: Set Section Title

### DIFF
--- a/magicbyirineu/Modules/CardList/View/Cells/SetCollectionReusableView.swift
+++ b/magicbyirineu/Modules/CardList/View/Cells/SetCollectionReusableView.swift
@@ -7,6 +7,7 @@ class SetCollectionReusableView: UICollectionReusableView, Reusable {
         var view = UILabel(frame: .zero)
         view.textColor = UIColor.white
         view.font = UIFont.sfProDisplay(size: 36, weight: .bold)
+        view.adjustsFontSizeToFitWidth = true
         return view
     }()
 
@@ -39,7 +40,7 @@ extension SetCollectionReusableView: CodeView {
     func setupConstraints() {
         label.snp.makeConstraints { make in
             make.top.bottom.equalToSuperview()
-            make.left.right.equalTo(16)
+            make.left.right.equalToSuperview().inset(16)
         }
 
         blurEffectView.snp.makeConstraints { make in

--- a/magicbyirineu/Modules/TabBar/MagicTabBarController.swift
+++ b/magicbyirineu/Modules/TabBar/MagicTabBarController.swift
@@ -38,8 +38,9 @@ class MagicTabBarController: UITabBarController {
         layerGradient.startPoint = CGPoint(x: 0.5, y: 0)
         layerGradient.endPoint = CGPoint(x: 0.5, y: 0.1)
         layerGradient.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: view.bounds.height)
+        layerGradient.zPosition = -1
         tabBar.layer.addSublayer(layerGradient)
-
+    
         let tabBarBackground = UIImage(color: .clear, size: tabBar.frame.size)
 
         tabBar.backgroundColor = .clear
@@ -80,7 +81,7 @@ class MagicTabBarController: UITabBarController {
         let tabbarFont = UIFont.sfProDisplay(size: 16, weight: .bold)
 
         item.setTitleTextAttributes([
-            NSAttributedString.Key.foregroundColor: UIColor(red: 0.73, green: 0.73, blue: 0.78, alpha: 1.0),
+            NSAttributedString.Key.foregroundColor: UIColor.lightGray,
             NSAttributedString.Key.font: tabbarFont as Any,
         ], for: UIControl.State.normal)
 


### PR DESCRIPTION
- Set title now responds to the view width. If it is too big, the font scale will be smaller in order for it to fit correctly.

- TabBar's gradient layer was overlapping the Tab's titles. This was fixed.